### PR TITLE
No longer ignore user provided 'resourcename'

### DIFF
--- a/src/Facade/CalDavClient.php
+++ b/src/Facade/CalDavClient.php
@@ -213,7 +213,9 @@ final class CalDavClient implements ICalDavClient
     public function createCalendar($calendar_home_set, MakeCalendarRequestVO $vo)
     {
         $uid           = $vo->getUID();
-        $resource_url  = $calendar_home_set.$uid;
+        $resource_name = $vo->getResourceName();
+
+        $resource_url  = $calendar_home_set . ($resource_name ? $resource_name : $uid);
         $http_response = $this->makeRequest(
             RequestFactory::createMakeCalendarRequest
             (


### PR DESCRIPTION
When creating a calendar you can provide a resource name in the MakeCalendarRequestVO, but this resource name was ignored when doing the actual call to the server. This commit checks if you have provided a resource name, and will try to create a calendar using that resource name if you did. If you did not provide a resource name, it will revert to the previous behaviour of using a UID for the calendar name.