### PR TITLE
CalendarDeletedResponse accepts 2 arguments, not 3

### DIFF
--- a/src/Facade/CalDavClient.php
+++ b/src/Facade/CalDavClient.php
@@ -438,7 +438,7 @@ final class CalDavClient implements ICalDavClient
 
         return new CalendarDeletedResponse
         (
-            $this->server_url, (string)$http_response->getBody(), $http_response->getStatusCode()
+            (string)$http_response->getBody(), $http_response->getStatusCode()
         );
     }
 }


### PR DESCRIPTION
It accepts a 'body' and (return) 'code' argument, but in the code here 'calendar_url' was erroneously passed in as first argument