### PR TITLE
Add omitted namespace

### DIFF
--- a/src/Facade/Requests/AbstractPropFindWebDAVRequest.php
+++ b/src/Facade/Requests/AbstractPropFindWebDAVRequest.php
@@ -31,13 +31,14 @@ abstract class AbstractPropFindWebDAVRequest implements IAbstractWebDAVRequest
         $service = new Service();
 
         $service->namespaceMap = [
-            'DAV:'                          => 'D',
-            'urn:ietf:params:xml:ns:caldav' => 'C'
+            'DAV:'                           => 'D',
+            'urn:ietf:params:xml:ns:caldav'  => 'C',
+            'http://calendarserver.org/ns/:' => 'CS',
         ];
 
         $elements = [];
         foreach( $this->properties as $val ) {
-            $elements[] = [  $val => ""];
+            $elements[] = [  $val => "" ];
         }
         return $service->write('{DAV:}propfind',
             [

--- a/src/Facade/Requests/AbstractPropFindWebDAVRequest.php
+++ b/src/Facade/Requests/AbstractPropFindWebDAVRequest.php
@@ -33,7 +33,7 @@ abstract class AbstractPropFindWebDAVRequest implements IAbstractWebDAVRequest
         $service->namespaceMap = [
             'DAV:'                           => 'D',
             'urn:ietf:params:xml:ns:caldav'  => 'C',
-            'http://calendarserver.org/ns/:' => 'CS',
+            'http://calendarserver.org/ns/'  => 'CS',
         ];
 
         $elements = [];

--- a/src/Facade/Requests/GetCalendarRequest.php
+++ b/src/Facade/Requests/GetCalendarRequest.php
@@ -29,7 +29,7 @@ final class GetCalendarRequest extends AbstractPropFindWebDAVRequest
             '{DAV:}resourcetype',
             '{DAV:}sync-token',
             '{DAV:}getetag',
-            '{http://calendarserver.org/ns/:}getctag',
+            '{http://calendarserver.org/ns/}getctag',
         ];
     }
 }

--- a/src/Facade/Requests/GetCalendarsRequest.php
+++ b/src/Facade/Requests/GetCalendarsRequest.php
@@ -21,7 +21,7 @@ final class GetCalendarsRequest extends AbstractPropFindWebDAVRequest
         $this->properties = [
             '{DAV:}resourcetype',
             '{DAV:}displayname',
-            '{http://calendarserver.org/ns/:}getctag',
+            '{http://calendarserver.org/ns/}getctag',
             '{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set',
         ];
     }


### PR DESCRIPTION
In the GetCalendarRequest and GetCalendarsRequest you use the {http://calendarserver.org/ns/:} namespace, but that one was not declared at the top of the XML document.

It's a superficial change only, the old code returns the same results from the CalDav server as the new code. However, the generated XML from the old code is somewhat quaint:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<D:propfind xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
   <D:prop>
      <D:displayname />
      <D:resourcetype />
      <D:sync-token />
      <D:getetag />
      <x1:getctag xmlns:x1="http://calendarserver.org/ns/:" />
   </D:prop>
</D:propfind>
```

The new code generates

```xml
<?xml version="1.0" encoding="UTF-8"?>
<D:propfind xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:CS="http://calendarserver.org/ns/:">
   <D:prop>
      <D:displayname />
      <D:resourcetype />
      <D:sync-token />
      <D:getetag />
      <CS:getctag />
   </D:prop>
</D:propfind>
```