### PR TITLE
Add $depth parameter in getCalendar request

### DIFF
--- a/src/Facade/CalDavClient.php
+++ b/src/Facade/CalDavClient.php
@@ -260,16 +260,17 @@ final class CalDavClient implements ICalDavClient
 
     /**
      * @param string $calendar_url
+     * @param int $depth Defaults to 0 to obtain calendar metadata. Set to 1 to obtain (all) calendar contents as well.
      * @return GetCalendarResponse
      */
-    public function getCalendar($calendar_url)
+    public function getCalendar($calendar_url, $depth = 0)
     {
         $http_response = $this->makeRequest(
             RequestFactory::createPropFindRequest
             (
                 $calendar_url,
                 CalDAVRequestFactory::getInstance()->build(CalDAVRequestFactory::CalendarRequestType)->getContent(),
-                0
+                $depth
             )
         );
 

--- a/src/Facade/CalDavClient.php
+++ b/src/Facade/CalDavClient.php
@@ -24,7 +24,7 @@ use CalDAVClient\Facade\Responses\CalendarSyncInfoResponse;
 use CalDAVClient\Facade\Responses\EventCreatedResponse;
 use CalDAVClient\Facade\Responses\EventDeletedResponse;
 use CalDAVClient\Facade\Responses\EventUpdatedResponse;
-use CalDAVClient\Facade\Responses\GetCalendarResponse;
+use CalDAVClient\Facade\Responses\GetCalendarMultiResponse;
 use CalDAVClient\Facade\Responses\GetCalendarsResponse;
 use CalDAVClient\Facade\Responses\ResourceCollectionResponse;
 use CalDAVClient\Facade\Responses\UserPrincipalResponse;
@@ -261,7 +261,8 @@ final class CalDavClient implements ICalDavClient
     /**
      * @param string $calendar_url
      * @param int $depth Defaults to 0 to obtain calendar metadata. Set to 1 to obtain (all) calendar contents as well.
-     * @return GetCalendarResponse
+     * @return GetCalendarMultiResponse
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function getCalendar($calendar_url, $depth = 0)
     {
@@ -274,7 +275,7 @@ final class CalDavClient implements ICalDavClient
             )
         );
 
-        return new GetCalendarResponse($this->server_url, (string)$http_response->getBody(), $http_response->getStatusCode());
+        return new GetCalendarMultiResponse($this->server_url, (string)$http_response->getBody(), $http_response->getStatusCode());
     }
 
 

--- a/src/Facade/Responses/ETagEntityMultiResponse.php
+++ b/src/Facade/Responses/ETagEntityMultiResponse.php
@@ -1,0 +1,12 @@
+<?php namespace CalDAVClient\Facade\Responses;
+
+class ETagEntityMultiResponse extends GenericMultiCalDAVResponse
+{
+    /**
+     * @return ETagEntityResponse
+     */
+    protected function buildSingleResponse()
+    {
+        return new ETagEntityResponse();
+    }
+}

--- a/src/Facade/Responses/GenericSinglePROPFINDCalDAVResponse.php
+++ b/src/Facade/Responses/GenericSinglePROPFINDCalDAVResponse.php
@@ -94,6 +94,6 @@ class GenericSinglePROPFINDCalDAVResponse extends AbstractCalDAVResponse
      */
     public function isSuccessFull()
     {
-        return $this->code == HttpResponse::HttpCodeMultiResponse;
+        return ($this->code == HttpResponse::HttpCodeMultiResponse || $this->code == HttpResponse::HttpCodeOk);
     }
 }

--- a/src/Facade/Responses/GetCalendarMultiResponse.php
+++ b/src/Facade/Responses/GetCalendarMultiResponse.php
@@ -13,31 +13,18 @@
  **/
 
 /**
- * Class GetCalendarResponse
+ * Class GetCalendarMultiResponse
  * @package CalDAVClient\Facade\Responses
  */
-final class GetCalendarResponse extends GenericSinglePROPFINDCalDAVResponse
+final class GetCalendarMultiResponse extends GenericMultiCalDAVResponse
 {
-    /**
-     * @return string
-     */
-    public function getDisplayName(){
-        return isset($this->found_props['displayname']) ? $this->found_props['displayname'] : null;
-    }
 
     /**
-     * @see https://tools.ietf.org/html/rfc6578
-     * @return string
+     * @return GenericSinglePROPFINDCalDAVResponse
      */
-    public function getSyncToken(){
-        return isset($this->found_props['sync-token']) ? $this->found_props['sync-token'] : null;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCTag(){
-        return isset($this->found_props['getctag']) ? $this->found_props['getctag'] : null;
+    protected function buildSingleResponse()
+    {
+        return new GetCalendarResponse();
     }
 
 }

--- a/src/Facade/Responses/GetCalendarMultiResponse.php
+++ b/src/Facade/Responses/GetCalendarMultiResponse.php
@@ -20,7 +20,7 @@ final class GetCalendarMultiResponse extends GenericMultiCalDAVResponse
 {
 
     /**
-     * @return GenericSinglePROPFINDCalDAVResponse
+     * @return GetCalendarResponse
      */
     protected function buildSingleResponse()
     {

--- a/src/Facade/Responses/GetCalendarResponse.php
+++ b/src/Facade/Responses/GetCalendarResponse.php
@@ -16,7 +16,7 @@
  * Class GetCalendarResponse
  * @package CalDAVClient\Facade\Responses
  */
-final class GetCalendarResponse extends ETagEntityResponse
+final class GetCalendarResponse extends ETagEntityMultiResponse
 {
     /**
      * @return string

--- a/src/Facade/Responses/GetCalendarsResponse.php
+++ b/src/Facade/Responses/GetCalendarsResponse.php
@@ -26,7 +26,7 @@ final class GetCalendarsResponse extends GenericMultiCalDAVResponse
      */
     protected function buildSingleResponse()
     {
-        return new GetCalendarResponse();
+        return new GetCalendarMultiResponse();
     }
 }
 

--- a/src/ICalDavClient.php
+++ b/src/ICalDavClient.php
@@ -21,7 +21,7 @@ use CalDAVClient\Facade\Responses\CalendarSyncInfoResponse;
 use CalDAVClient\Facade\Responses\EventCreatedResponse;
 use CalDAVClient\Facade\Responses\EventDeletedResponse;
 use CalDAVClient\Facade\Responses\EventUpdatedResponse;
-use CalDAVClient\Facade\Responses\GetCalendarResponse;
+use CalDAVClient\Facade\Responses\GetCalendarMultiResponse;
 use CalDAVClient\Facade\Responses\GetCalendarsResponse;
 use CalDAVClient\Facade\Responses\ResourceCollectionResponse;
 use CalDAVClient\Facade\Responses\UserPrincipalResponse;
@@ -86,7 +86,7 @@ interface ICalDavClient
 
     /**
      * @param string $calendar_url
-     * @return GetCalendarResponse
+     * @return GetCalendarMultiResponse
      */
     public function getCalendar($calendar_url);
 

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -75,10 +75,14 @@ final class FacadeTest extends PHPUnit_Framework_TestCase
     }
 
     function testGetCalendar(){
-        $res  = self::$client->getCalendar(getenv('CALDAV_SERVER_URL').'/8244464267/calendars/openstack-summit-sidney-2017/');
-        $this->assertTrue($res->isSuccessFull());
-        $this->assertTrue(!empty($res->getDisplayName()));
-        $this->assertTrue(!empty($res->getSyncToken()));
+        $responses = self::$client->getCalendar($this->getCalendarUrl())->getResponses();
+
+        foreach ($responses as $res) {
+            $this->assertTrue($res->isSuccessFull(), "Calendar request not successful");
+            $this->assertTrue(!empty($res->getDisplayName()), "Display name not set");
+            $this->assertTrue(!empty($res->getSyncToken()), "Sync-token empty");
+        }
+        return $responses[0];
     }
 
     function testSyncCalendar(){


### PR DESCRIPTION
This allows the user to retrieve all the objects in the calendar.