### PR TITLE
Add CalendarHomesMultiResponse

### DIFF
--- a/src/Facade/CalDavClient.php
+++ b/src/Facade/CalDavClient.php
@@ -20,7 +20,7 @@ use CalDAVClient\Facade\Requests\CalendarQueryFilter;
 use CalDAVClient\Facade\Requests\EventRequestVO;
 use CalDAVClient\Facade\Requests\MakeCalendarRequestVO;
 use CalDAVClient\Facade\Responses\CalendarDeletedResponse;
-use CalDAVClient\Facade\Responses\CalendarHomesResponse;
+use CalDAVClient\Facade\Responses\CalendarHomesMultiResponse;
 use CalDAVClient\Facade\Responses\CalendarSyncInfoResponse;
 use CalDAVClient\Facade\Responses\EventCreatedResponse;
 use CalDAVClient\Facade\Responses\EventDeletedResponse;
@@ -208,7 +208,7 @@ final class CalDavClient implements ICalDavClient
 
     /**
      * @param string $principal_url
-     * @return CalendarHomesResponse
+     * @return CalendarHomesMultiResponse
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function getCalendarHome($principal_url)
@@ -221,7 +221,7 @@ final class CalDavClient implements ICalDavClient
             )
         );
 
-        return new CalendarHomesResponse($this->server_url, (string)$http_response->getBody(), $http_response->getStatusCode());
+        return new CalendarHomesMultiResponse($this->server_url, (string)$http_response->getBody(), $http_response->getStatusCode());
     }
 
     /**

--- a/src/Facade/Responses/CalendarHomesMultiResponse.php
+++ b/src/Facade/Responses/CalendarHomesMultiResponse.php
@@ -1,0 +1,30 @@
+<?php namespace CalDAVClient\Facade\Responses;
+/**
+ * Copyright 2017 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+/**
+ * Class CalendarHomesMultiResponse
+ * @package CalDAVClient\Facade\Responses
+ */
+final class CalendarHomesMultiResponse extends GenericMultiCalDAVResponse
+{
+
+    /**
+     * @return CalendarHomesResponse
+     */
+    protected function buildSingleResponse()
+    {
+        return new CalendarHomesResponse();
+    }
+
+}

--- a/src/ICalDavClient.php
+++ b/src/ICalDavClient.php
@@ -16,7 +16,7 @@ use CalDAVClient\Facade\Requests\CalendarQueryFilter;
 use CalDAVClient\Facade\Requests\EventRequestVO;
 use CalDAVClient\Facade\Requests\MakeCalendarRequestVO;
 use CalDAVClient\Facade\Responses\CalendarDeletedResponse;
-use CalDAVClient\Facade\Responses\CalendarHomesResponse;
+use CalDAVClient\Facade\Responses\CalendarHomesMultiResponse;
 use CalDAVClient\Facade\Responses\CalendarSyncInfoResponse;
 use CalDAVClient\Facade\Responses\EventCreatedResponse;
 use CalDAVClient\Facade\Responses\EventDeletedResponse;
@@ -59,7 +59,7 @@ interface ICalDavClient
 
     /**
      * @param string $principal_url
-     * @return CalendarHomesResponse
+     * @return CalendarHomesMultiResponse
      */
     public function getCalendarHome($principal_url);
 

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -86,26 +86,31 @@ final class FacadeTest extends PHPUnit_Framework_TestCase
         $caldav_path = getenv("CALDAV_SERVER_PATH");
 
         $principal_url = $this->testPrincipal();
-        $res    = self::$client->getCalendarHome($caldav_host . $principal_url);
-        $url    = $res->getCalendarHomeSetUrl();
+        $homes  = self::$client->getCalendarHome($caldav_host . $principal_url)->getResponses();
+        foreach ($homes as $res) {
+            $url    = $res->getCalendarHomeSetUrl();
 
-        $this->assertTrue(!empty($url), "Calendar home URL is empty");
-        // $host = $res->getRealCalDAVHost();
-        // echo sprintf('calendar home is %s', $url).PHP_EOL;
-        // echo sprintf('host is %s', $caldav_host).PHP_EOL;
+            $this->assertTrue(!empty($url), "Calendar home URL is empty");
+            // $host = $res->getRealCalDAVHost();
+            // echo sprintf('calendar home is %s', $url).PHP_EOL;
+            // echo sprintf('host is %s', $caldav_host).PHP_EOL;
 
-        // first, ensures that the 'home' path is relative to the CalDav server
-        // (this differs between servers)
-        $path_without_prefix = $url;
-        if (strpos($path_without_prefix, $caldav_host) === 0) {
-            $path_without_prefix = substr($path_without_prefix, strlen($caldav_host));
+            // first, ensures that the 'home' path is relative to the CalDav server
+            // (this differs between servers)
+            $path_without_prefix = $url;
+            if (strpos($path_without_prefix, $caldav_host) === 0) {
+                $path_without_prefix = substr($path_without_prefix, strlen($caldav_host));
+            }
+            if (strpos($path_without_prefix, $caldav_path) === 0) {
+                $path_without_prefix = substr($path_without_prefix, strlen($caldav_path));
+            }
+
+            // then, turn the URL into an absolute URL so that we always know what to expect
+            self::$calendar_home = $caldav_host . $caldav_path . $path_without_prefix;
+
+            // stop after first response
+            break;
         }
-        if (strpos($path_without_prefix, $caldav_path) === 0) {
-            $path_without_prefix = substr($path_without_prefix, strlen($caldav_path));
-        }
-
-        // then, turn the URL into an absolute URL so that we always know what to expect
-        self::$calendar_home = $caldav_host . $caldav_path . $path_without_prefix;
     }
 
     function testGetCalendars(){


### PR DESCRIPTION
Principals can have subprincipals (calendar-proxy-read and calendar-proxy-write) in which case more than one CalendarHomeResponse is returned. This pull request provides code to deal with that.