### PR TITLE
Add support to change request contents

### DIFF
--- a/src/Facade/Requests/CalDAVRequestFactory.php
+++ b/src/Facade/Requests/CalDAVRequestFactory.php
@@ -16,32 +16,29 @@
  * Class CalDAVRequestFactory
  * @package CalDAVClient\Facade\Requests
  */
-final class CalDAVRequestFactory
+final class CalDAVRequestFactory implements ICalDAVRequestFactory
 {
-    const PrincipalRequestType        = 'PRINCIPAL';
-    const CalendarHomeRequestType     = 'CALENDAR_HOME';
-    const CalendarsRequestType        = 'CALENDARS';
-    const CalendarRequestType         = 'CALENDAR';
-    const CalendarSyncRequestType     = 'CALENDAR_SYNC';
-    const CalendarMultiGetRequestType = 'CALENDAR_MULTIGET';
-    const CalendarQueryRequestType    = 'CALENDAR_QUERY';
-    const CalendarCreateRequestType   = 'CREATE_CALENDAR';
-    const EventCreateRequestType      = 'CREATE_EVENT';
-    const EventUpdateRequestType      = 'UPDATE_EVENT';
-
     private function __construct(){}
 
     /**
-     * @var CalDAVRequestFactory
+     * @var ICalDAVRequestFactory
      */
     private static $instance;
 
     /**
-     * @return CalDAVRequestFactory
+     * @return ICalDAVRequestFactory
      */
     public static function getInstance(){
         if(is_null(self::$instance)) self::$instance = new CalDAVRequestFactory();
         return self::$instance;
+    }
+
+    /**
+     * Override which class is used to create new request objects.
+     * @param ICalDAVRequestFactory $factory
+     */
+    public static function setInstance(ICalDAVRequestFactory $factory) {
+        self::$instance = $factory;
     }
 
     /**

--- a/src/Facade/Requests/ICalDAVRequestFactory.php
+++ b/src/Facade/Requests/ICalDAVRequestFactory.php
@@ -1,0 +1,40 @@
+<?php namespace CalDAVClient\Facade\Requests;
+/**
+ * Copyright 2019 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+/**
+ * Interface ICalDAVRequestFactory
+ * @package CalDAVClient\Facade\Requests
+ */
+interface ICalDAVRequestFactory {
+    const PrincipalRequestType        = 'PRINCIPAL';
+    const CalendarHomeRequestType     = 'CALENDAR_HOME';
+    const CalendarsRequestType        = 'CALENDARS';
+    const CalendarRequestType         = 'CALENDAR';
+    const CalendarSyncRequestType     = 'CALENDAR_SYNC';
+    const CalendarMultiGetRequestType = 'CALENDAR_MULTIGET';
+    const CalendarQueryRequestType    = 'CALENDAR_QUERY';
+    const CalendarCreateRequestType   = 'CREATE_CALENDAR';
+    const EventCreateRequestType      = 'CREATE_EVENT';
+    const EventUpdateRequestType      = 'UPDATE_EVENT';
+
+    /**
+     * Builds a request of a certain type.
+     *
+     * @param string $type
+     * @param array $params
+     * @return IAbstractWebDAVRequest|null
+     * @throws \InvalidArgumentException
+     */
+    public function build($type, $params = []);
+}

--- a/src/Facade/Responses/GenericSinglePROPFINDCalDAVResponse.php
+++ b/src/Facade/Responses/GenericSinglePROPFINDCalDAVResponse.php
@@ -90,6 +90,20 @@ class GenericSinglePROPFINDCalDAVResponse extends AbstractCalDAVResponse
     }
 
     /**
+     * @return array
+     */
+    public function getFoundProps() {
+        return $this->found_props;
+    }
+
+    /**
+     * @return array
+     */
+    public function getNotFoundProps() {
+        return $this->not_found_props;
+    }
+
+    /**
      * @return bool
      */
     public function isSuccessFull()


### PR DESCRIPTION
This pull request add support to change which requests are issued. It does this by allowing you to inject a different implementation of the (new) ICalDAVRequestFactory into the CalDAVRequestFactory, thereby adding support to change what goes into a specific request.

It also adds support to retrieve the full list of found properties of a request.

My use case is that I added a custom property to my calendars, and I want to request that property. However, I either do not understand the Facades or I might have missed how I can change the outgoing requests. Every class is final (which is a good thing), but there are no ways do to dependency injection either.

With this implementation I can now do the following:

```php
    CalDAVRequestFactory::setInstance(new Calendar\CalDAVRequestFactory());

    $this->client = new CalDavClient(....)
```

and then in ```Calendar\CalDAVRequestFactory```:

```php
namespace App\Helpers\Calendar;

use CalDAVClient\Facade\Requests\IAbstractWebDAVRequest,
    CalDAVClient\Facade\Requests\ICalDAVRequestFactory,
    CalDAVClient\Facade\Requests\UserPrincipalRequest,
    CalDAVClient\Facade\Requests\CalendarHomeRequest,
    CalDAVClient\Facade\Requests\GetCalendarRequest,
    CalDAVClient\Facade\Requests\CalendarSyncRequest,
    CalDAVClient\Facade\Requests\CalendarMultiGetRequest,
    CalDAVClient\Facade\Requests\CalendarQueryRequest,
    CalDAVClient\Facade\Requests\CalendarCreateRequest,
    CalDAVClient\Facade\Requests\EventCreateRequest,
    CalDAVClient\Facade\Requests\EventUpdateRequest,

    // redefine the GetCalendarsRequest
    App\Helpers\Calendar\Requests\GetCalendarsRequest;


class CalDAVRequestFactory implements ICalDAVRequestFactory {

    /**
     * Builds a request of a certain type.
     *
     * @param string $type
     * @param array $params
     * @return IAbstractWebDAVRequest|null
     * @throws \InvalidArgumentException
     */
    public function build($type, $params = [])
    {
          // omitted for brevity, basically literally copy-pasted from the default CalDAVRequestFactory
    }
}
```

This would then allow me to define my custom request in ```App\Helpers\Calendar\Requests\GetCalendarsRequest```, and I can access my custom property as follows:

```php
/**
 * @var $calendars \CalDAVClient\Facade\Responses\GetCalendarsResponse
 */
$calendars = $this->client->getCalendars($calendar_home_url);

/**
 * @var $responses[] \CalDAVClient\Facade\Responses\GetCalendarMultiResponse
 */
$responses = $calendars->getResponses();

/**
 * @var $multiresponse \CalDAVClient\Facade\Responses\GetCalendarMultiResponse
 */
foreach ($responses as $multiresponse) {

    /**
     * @var $multi[] \CalDAVClient\Facade\Responses\GetCalendarResponse
     */
    $multi = $multiresponse->getResponses();

    /**
     * @var $r \CalDAVClient\Facade\Responses\GetCalendarResponse
     */
    foreach ($multi as $r) {
        $props = $r->getFoundProps();

        if (!empty($r->getDisplayName())) {

            $list[] = [
                'title' => $r->getDisplayName(),
                'link' => $r->getHRef(),
                'color' => $r->getColor(),
                'ctag' => $r->getCTag(),
                'MY_CUSTOM_PROPERTY => $props['MY_CUSTOM_PROPERTY'] 
            ];
        }
    }
}
```

I've toyed with the idea of having a DefaultCalDAVRequestFactory or an AbstractCalDAVRequestFactory so that I did not have to copy-paste the 'build' method and could just do ```parent::build()```or ```$this->buildDefault()``` or something, but they were all messy and I didn't find a clean / satisfactory solution.