### PR TITLE
ETagEntityResponse status propstat fixes

### DIFF
--- a/src/Facade/Responses/ETagEntityResponse.php
+++ b/src/Facade/Responses/ETagEntityResponse.php
@@ -30,6 +30,9 @@ class ETagEntityResponse extends GenericSinglePROPFINDCalDAVResponse
      */
     public function getStatus()
     {
-        return isset($this->content['response']['status']) ? $this->content['response']['status'] : null;
+        if(isset($this->content['response']['status']))             return $this->content['response']['status'];
+        if(isset($this->content['response']['propstat']['status'])) return $this->content['response']['propstat']['status'];
+
+        return null;
     }
 }


### PR DESCRIPTION
Accomodated for status being nested in propstat element in Apple ICalendar CalendarSyncInfoResponse ETagEntityResponse body.